### PR TITLE
Inferring types  from macros

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -761,7 +761,7 @@ dependencies = [
 
 [[package]]
 name = "cw81"
-version = "0.2.0"
+version = "1.0.0"
 dependencies = [
  "cosmwasm-crypto",
  "cosmwasm-schema",
@@ -812,7 +812,7 @@ dependencies = [
 
 [[package]]
 name = "cw82"
-version = "0.2.0"
+version = "1.0.0"
 dependencies = [
  "cosmwasm-crypto",
  "cosmwasm-schema",
@@ -840,7 +840,7 @@ dependencies = [
 
 [[package]]
 name = "cw82-key-account"
-version = "0.2.0"
+version = "1.0.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -855,7 +855,7 @@ dependencies = [
 
 [[package]]
 name = "cw82-token-account"
-version = "0.2.0"
+version = "1.0.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "cw83"
-version = "0.2.0"
+version = "1.0.0"
 dependencies = [
  "cosmwasm-crypto",
  "cosmwasm-schema",
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "cw83-tba-registry"
-version = "0.2.0"
+version = "1.0.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -996,7 +996,7 @@ checksum = "23d2f3407d9a573d666de4b5bdf10569d73ca9478087346697dcbae6244bfbcd"
 
 [[package]]
 name = "e2e"
-version = "0.2.0"
+version = "1.0.0"
 dependencies = [
  "assert_matches",
  "async-trait",

--- a/contracts/cw81-last-signature/src/msg.rs
+++ b/contracts/cw81-last-signature/src/msg.rs
@@ -1,6 +1,6 @@
 use cosmwasm_std::Binary;
 use cosmwasm_schema::{cw_serde, QueryResponses};
-use cw81::{valid_signature_query, ValidSignatureResponse, ValidSignaturesResponse};
+use cw81::valid_signature_query;
 use cw_utils::Expiration;
 
 #[cw_serde]

--- a/contracts/cw81-pubkey/src/msg.rs
+++ b/contracts/cw81-pubkey/src/msg.rs
@@ -1,6 +1,6 @@
 use cosmwasm_std::Binary;
 use cosmwasm_schema::{cw_serde, QueryResponses};
-use cw81::{valid_signature_query, ValidSignatureResponse, ValidSignaturesResponse};
+use cw81::valid_signature_query;
 
 #[cw_serde]
 pub struct InstantiateMsg {

--- a/contracts/cw82-key-account/src/msg.rs
+++ b/contracts/cw82-key-account/src/msg.rs
@@ -2,9 +2,7 @@ use cosmwasm_std::{Binary, Empty, CosmosMsg};
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cw82::{
     smart_account_query, 
-    CanExecuteResponse, 
-    ValidSignatureResponse, 
-    ValidSignaturesResponse, Cw82ExecuteMsg
+    Cw82ExecuteMsg
 };
 
 #[cw_serde]

--- a/contracts/cw82-token-account/src/contract.rs
+++ b/contracts/cw82-token-account/src/contract.rs
@@ -23,11 +23,11 @@ use crate::{
         try_freeze, 
         try_unfreeze, 
         try_change_pubkey
-    }, 
+    }, utils::query_if_registry, 
 };
 
 #[cfg(target_arch = "wasm32")]
-use crate::utils::is_factory;
+use crate::utils::is_registry;
 
 pub const CONTRACT_NAME: &str = "crates:cw82-token-account";
 pub const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -64,7 +64,7 @@ pub fn instantiate(deps: DepsMut, _ : Env, info : MessageInfo, msg : Instantiate
     )?;
 
     #[cfg(target_arch = "wasm32")]
-    if !is_factory(deps.as_ref(), info.sender.clone())? {
+    if !query_if_registry(&deps.querier, info.sender.clone())? {
         return Err(ContractError::Unauthorized {})
     };
 

--- a/contracts/cw82-token-account/src/contract.rs
+++ b/contracts/cw82-token-account/src/contract.rs
@@ -23,11 +23,11 @@ use crate::{
         try_freeze, 
         try_unfreeze, 
         try_change_pubkey
-    }, utils::query_if_registry, 
+    } 
 };
 
 #[cfg(target_arch = "wasm32")]
-use crate::utils::is_registry;
+use crate::utils::query_if_registry;
 
 pub const CONTRACT_NAME: &str = "crates:cw82-token-account";
 pub const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/contracts/cw82-token-account/src/execute.rs
+++ b/contracts/cw82-token-account/src/execute.rs
@@ -3,7 +3,7 @@ use cosmwasm_std::{
 };
 
 use cw_ownable::{assert_owner, initialize_owner, is_owner};
-use crate::{error::ContractError, utils::{assert_factory, is_ok_cosmos_msg, assert_status}, state::{KNOWN_TOKENS, PUBKEY, STATUS}, msg::Status};
+use crate::{error::ContractError, utils::{assert_registry, is_ok_cosmos_msg, assert_status}, state::{KNOWN_TOKENS, PUBKEY, STATUS}, msg::Status};
 
 
 
@@ -26,7 +26,7 @@ pub fn try_freeze(
     deps: DepsMut,
     sender: Addr
 ) -> Result<Response, ContractError> {
-    assert_factory(deps.as_ref(), sender)?;
+    assert_registry(deps.storage, sender)?;
     STATUS.save(deps.storage, &Status { frozen: true })?;
     Ok(Response::default())
 }
@@ -36,7 +36,7 @@ pub fn try_unfreeze(
     deps: DepsMut,
     sender: Addr,
 ) -> Result<Response, ContractError> {
-    assert_factory(deps.as_ref(), sender)?;
+    assert_registry(deps.storage, sender)?;
     STATUS.save(deps.storage, &Status { frozen: false })?;
     Ok(Response::default())
 }
@@ -61,7 +61,7 @@ pub fn try_update_ownership(
     new_owner: String,
     new_pubkey: Binary
 ) -> Result<Response, ContractError> {
-    assert_factory(deps.as_ref(), sender)?;
+    assert_registry(deps.storage, sender)?;
     initialize_owner(deps.storage, deps.api, Some(&new_owner))?;
     STATUS.save(deps.storage, &Status { frozen: false })?;
     PUBKEY.save(deps.storage, &new_pubkey)?;

--- a/contracts/cw82-token-account/src/utils.rs
+++ b/contracts/cw82-token-account/src/utils.rs
@@ -1,5 +1,8 @@
-use cosmwasm_std::{Addr, Deps, StdResult, Binary, StdError, from_binary, CosmosMsg, WasmMsg, Storage, QuerierWrapper};
+use cosmwasm_std::{Addr, StdResult, Binary, StdError, from_binary, CosmosMsg, WasmMsg, Storage};
 use crate::{msg::PayloadInfo, error::ContractError, state::{STATUS, REGISTRY_ADDRESS}};
+
+#[cfg(target_arch = "wasm32")]
+use cosmwasm_std::QuerierWrapper;
 
 pub fn assert_status(
     store: &dyn Storage
@@ -46,6 +49,7 @@ pub fn is_ok_cosmos_msg(
 }
 
 
+#[cfg(target_arch = "wasm32")]
 pub fn query_if_registry(
     querier: &QuerierWrapper,
     addr: Addr

--- a/contracts/cw82-token-account/src/utils.rs
+++ b/contracts/cw82-token-account/src/utils.rs
@@ -1,5 +1,5 @@
-use cosmwasm_std::{Addr, Deps, StdResult, Binary, StdError, from_binary, CosmosMsg, WasmMsg, Storage};
-use crate::{msg::PayloadInfo, error::ContractError, state::STATUS};
+use cosmwasm_std::{Addr, Deps, StdResult, Binary, StdError, from_binary, CosmosMsg, WasmMsg, Storage, QuerierWrapper};
+use crate::{msg::PayloadInfo, error::ContractError, state::{STATUS, REGISTRY_ADDRESS}};
 
 pub fn assert_status(
     store: &dyn Storage
@@ -46,23 +46,33 @@ pub fn is_ok_cosmos_msg(
 }
 
 
-pub fn assert_factory(
-    deps: Deps,
+pub fn query_if_registry(
+    querier: &QuerierWrapper,
+    addr: Addr
+) -> StdResult<bool> {
+    cw83::Cw83RegistryBase(addr).supports_interface(querier)
+}
+
+
+
+pub fn assert_registry(
+    store: &dyn Storage,
     addr: Addr
 ) -> Result<(), ContractError> {
-    if is_factory(deps, addr)? {
+    if is_registry(store, addr)? {
         Ok(())
     } else {
         Err(ContractError::Unauthorized {})
     }
 }
 
-pub fn is_factory(
-    deps: Deps,
+pub fn is_registry(
+    store: &dyn Storage,
     addr: Addr
 ) -> StdResult<bool> {
-    cw83::Cw83RegistryBase(addr).supports_interface(&deps.querier)
+    REGISTRY_ADDRESS.load(store).map(|a| a == addr)
 }
+
 
 pub fn parse_payload(
     payload: &Option<Binary>

--- a/contracts/cw82-token-account/src/utils.rs
+++ b/contracts/cw82-token-account/src/utils.rs
@@ -61,7 +61,7 @@ pub fn is_factory(
     deps: Deps,
     addr: Addr
 ) -> StdResult<bool> {
-    cw83::Cw83RegistryBase(addr).supports_interface(deps)
+    cw83::Cw83RegistryBase(addr).supports_interface(&deps.querier)
 }
 
 pub fn parse_payload(

--- a/contracts/cw83-tba-registry/src/contract.rs
+++ b/contracts/cw83-tba-registry/src/contract.rs
@@ -118,7 +118,7 @@ pub fn reply(deps: DepsMut, _ : Env, msg : Reply)
         let addr = res.contract_address;
         let ver_addr = deps.api.addr_validate(addr.as_str())?;
 
-        Cw82Contract(ver_addr).supports_interface(deps.as_ref())?;
+        Cw82Contract(ver_addr).supports_interface(&deps.querier)?;
         
         let stored = LAST_ATTEMPTING.load(deps.storage)?;
         LAST_ATTEMPTING.remove(deps.storage);

--- a/contracts/cw83-tba-registry/src/helpers.rs
+++ b/contracts/cw83-tba-registry/src/helpers.rs
@@ -1,5 +1,5 @@
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::{Deps, to_binary, Binary, Addr, Coin, StdResult, CosmosMsg, SubMsg, ReplyOn};
+use cosmwasm_std::{Deps, to_binary, Binary, Addr, Coin, StdResult, CosmosMsg, SubMsg, ReplyOn, QuerierWrapper};
 use cw83::{Cw83RegistryBase, CREATE_ACCOUNT_REPLY_ID};
 
 use crate::{error::ContractError, msg::TokenInfo};
@@ -116,9 +116,9 @@ impl Cw83TokenRegistryContract {
     
     pub fn supports_interface(
         &self,
-        deps: Deps,
+        querier: &QuerierWrapper,
     ) -> StdResult<bool> {
-        self.cw83_wrap().supports_interface(deps)
+        self.cw83_wrap().supports_interface(querier)
     }
 
 }

--- a/contracts/cw83-tba-registry/src/msg.rs
+++ b/contracts/cw83-tba-registry/src/msg.rs
@@ -1,6 +1,6 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{Binary, Empty, Addr};
-use cw83::{registy_execute, registy_query, 
+use cw83::{registry_execute, registry_query, 
     CreateAccountMsg as CreateAccountMsgBase,
     AccountQuery as AccountQueryBase,
     AccountInfoResponse as AccountInfoResponseBase,
@@ -61,7 +61,7 @@ pub type AccountInfoResponse = AccountInfoResponseBase<Empty>;
 pub type CreateAccountMsg = CreateAccountMsgBase<CreateInitMsg>;
 
 
-#[registy_query]
+#[registry_query]
 #[cw_serde]
 #[derive(QueryResponses)]
 pub enum QueryMsg {
@@ -90,7 +90,7 @@ pub enum QueryMsg {
 pub struct MigrateMsg {}
 
 
-#[registy_execute]
+#[registry_execute]
 #[cw_serde]
 pub enum ExecuteMsg {
 

--- a/packages/cw81/README.md
+++ b/packages/cw81/README.md
@@ -117,10 +117,7 @@ enum QueryMsg {
 ```
 
 
-The response types must be imported as well for it to work
-```Rust
-use cw81::{valid_signature_query, ValidSignatureResponse, ValidSignaturesResponse};
-```
+Note: `cosmwasm_std`must be imported for definition of `Binary`
 
 ## Examples
 Example contracts can be found in this repository and are prefixed with `cw81-`  

--- a/packages/cw81/derive/src/lib.rs
+++ b/packages/cw81/derive/src/lib.rs
@@ -56,18 +56,18 @@ pub fn valid_signature_query(metadata: TokenStream, input: TokenStream) -> Token
         input,
         quote! {
             enum Right {
-                #[returns(ValidSignatureResponse)]
+                #[returns(::cw81::ValidSignatureResponse)]
                 ValidSignature {
-                    data: Binary,
-                    signature: Binary,
-                    payload: Option<Binary>
+                    data: ::cosmwasm_std::Binary,
+                    signature: ::cosmwasm_std::Binary,
+                    payload: Option<::cosmwasm_std::Binary>
                 },
 
-                #[returns(ValidSignaturesResponse)]
+                #[returns(::cw81::ValidSignaturesResponse)]
                 ValidSignatures {
-                    data: Vec<Binary>,
-                    signatures: Vec<Binary>,
-                    payload: Option<Binary>
+                    data: Vec<::cosmwasm_std::Binary>,
+                    signatures: Vec<::cosmwasm_std::Binary>,
+                    payload: Option<::cosmwasm_std::Binary>
                 }
             }
         }

--- a/packages/cw81/src/helpers.rs
+++ b/packages/cw81/src/helpers.rs
@@ -1,5 +1,5 @@
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::{Addr, StdResult, Binary, Deps, WasmQuery, to_binary, QueryRequest, from_binary};
+use cosmwasm_std::{Addr, StdResult, Binary, Deps, WasmQuery, to_binary, QueryRequest, from_binary, QuerierWrapper};
 
 use crate::{ValidSignatureResponse, Cw81QueryMsg, ValidSignaturesResponse};
 
@@ -16,7 +16,7 @@ impl Cw81Contract {
 
     pub fn valid_signature(
         &self, 
-        deps: Deps,
+        querier: &QuerierWrapper,
         data : Binary, 
         signature: Binary,
         payload: Option<Binary>
@@ -29,14 +29,14 @@ impl Cw81Contract {
                 payload
             })?
         };
-        let binary_res = deps.querier.query(&QueryRequest::Wasm(wasm_query))?;
+        let binary_res = querier.query(&QueryRequest::Wasm(wasm_query))?;
         from_binary(&binary_res)
     }
 
 
     pub fn valid_signatures(
         &self, 
-        deps: Deps,
+        querier: &QuerierWrapper,
         data : Vec<Binary>, 
         signatures: Vec<Binary>,
         payload: Option<Binary>
@@ -49,13 +49,13 @@ impl Cw81Contract {
                 payload
             })?
         };
-        let binary_res = deps.querier.query(&QueryRequest::Wasm(wasm_query))?;
+        let binary_res = querier.query(&QueryRequest::Wasm(wasm_query))?;
         from_binary(&binary_res)
     }
 
     pub fn supports_interface(
         &self,
-        deps: Deps,
+        querier: &QuerierWrapper,
     ) -> StdResult<bool> {
 
         let key = cosmwasm_std::storage_keys::namespace_with_key(
@@ -68,7 +68,7 @@ impl Cw81Contract {
             key: key.into()
         };
 
-        let version : Option<String> = deps.querier.query(&QueryRequest::Wasm(raw_query))?;
+        let version : Option<String> = querier.query(&QueryRequest::Wasm(raw_query))?;
         Ok(version.is_some())
     }
 }

--- a/packages/cw81/src/helpers.rs
+++ b/packages/cw81/src/helpers.rs
@@ -1,5 +1,5 @@
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::{Addr, StdResult, Binary, Deps, WasmQuery, to_binary, QueryRequest, from_binary, QuerierWrapper};
+use cosmwasm_std::{Addr, StdResult, Binary, WasmQuery, to_binary, QueryRequest, from_binary, QuerierWrapper};
 
 use crate::{ValidSignatureResponse, Cw81QueryMsg, ValidSignaturesResponse};
 

--- a/packages/cw81/src/msg.rs
+++ b/packages/cw81/src/msg.rs
@@ -1,11 +1,6 @@
 use cosmwasm_std::Binary;
 use cosmwasm_schema::{cw_serde, QueryResponses};
-use cw81_derive::valid_signature_query;
 
-#[valid_signature_query]
-#[cw_serde]
-#[derive(QueryResponses)]
-pub enum Cw81QueryMsg {}
 
 #[cw_serde]
 pub struct ValidSignatureResponse {
@@ -15,4 +10,22 @@ pub struct ValidSignatureResponse {
 #[cw_serde]
 pub struct ValidSignaturesResponse {
     pub are_valid: Vec<bool>
+}
+
+#[cw_serde]
+#[derive(QueryResponses)]
+pub enum Cw81QueryMsg {
+    #[returns(ValidSignatureResponse)]
+    ValidSignature {
+        data: Binary,
+        signature: Binary,
+        payload: Option<Binary>
+    },
+
+    #[returns(ValidSignaturesResponse)]
+    ValidSignatures {
+        data: Vec<Binary>,
+        signatures: Vec<Binary>,
+        payload: Option<Binary>
+    }
 }

--- a/packages/cw82/derive/src/lib.rs
+++ b/packages/cw82/derive/src/lib.rs
@@ -90,23 +90,25 @@ pub fn smart_account_query(metadata: TokenStream, input: TokenStream) -> TokenSt
             enum Right {
 
                 /// cw1
-                #[returns(CanExecuteResponse)]
-                CanExecute { sender: String, msg: CosmosMsg<T> },
-
-
-                /// cw81
-                #[returns(ValidSignatureResponse)]
-                ValidSignature {
-                    data: Binary,
-                    signature: Binary,
-                    payload: Option<Binary>
+                #[returns(::cw82::CanExecuteResponse)]
+                CanExecute { 
+                    sender: String, 
+                    msg: ::cosmwasm_std::CosmosMsg<T> 
                 },
 
-                #[returns(ValidSignaturesResponse)]
+                /// cw81
+                #[returns(::cw82::ValidSignatureResponse)]
+                ValidSignature {
+                    data: ::cosmwasm_std::Binary,
+                    signature: ::cosmwasm_std::Binary,
+                    payload: Option<::cosmwasm_std::Binary>
+                },
+
+                #[returns(::cw82::ValidSignaturesResponse)]
                 ValidSignatures {
-                    data: Vec<Binary>,
-                    signatures: Vec<Binary>,
-                    payload: Option<Binary>
+                    data: Vec<::cosmwasm_std::Binary>,
+                    signatures: Vec<::cosmwasm_std::Binary>,
+                    payload: Option<::cosmwasm_std::Binary>
                 }
             }
         }

--- a/packages/cw82/src/interface.rs
+++ b/packages/cw82/src/interface.rs
@@ -1,5 +1,5 @@
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::{CosmosMsg, Addr, StdResult, WasmMsg, to_binary, Binary, Deps, QueryRequest, WasmQuery, from_binary, Empty};
+use cosmwasm_std::{CosmosMsg, Addr, StdResult, WasmMsg, to_binary, Binary, Deps, QueryRequest, WasmQuery, from_binary, Empty, QuerierWrapper};
 use cw1::CanExecuteResponse;
 use cw81::{ValidSignatureResponse, ValidSignaturesResponse};
 
@@ -28,7 +28,7 @@ impl Cw82Contract {
 
     pub fn valid_signature(
         &self, 
-        deps: Deps,
+        querier: &QuerierWrapper,
         data : Binary, 
         signature: Binary,
         payload: Option<Binary>
@@ -41,14 +41,14 @@ impl Cw82Contract {
                 payload
             })?
         };
-        let binary_res = deps.querier.query(&QueryRequest::Wasm(wasm_query))?;
+        let binary_res = querier.query(&QueryRequest::Wasm(wasm_query))?;
         from_binary(&binary_res)
     }
 
 
     pub fn valid_signatures(
         &self, 
-        deps: Deps,
+        querier: &QuerierWrapper,
         data : Vec<Binary>, 
         signatures: Vec<Binary>,
         payload: Option<Binary>
@@ -61,14 +61,14 @@ impl Cw82Contract {
                 payload
             })?
         };
-        let binary_res = deps.querier.query(&QueryRequest::Wasm(wasm_query))?;
+        let binary_res = querier.query(&QueryRequest::Wasm(wasm_query))?;
         from_binary(&binary_res)
     }
 
 
     pub fn can_execute(
         &self, 
-        deps: Deps,
+        querier: &QuerierWrapper,
         sender : String, 
         msg: impl Into<CosmosMsg>,
     ) -> StdResult<CanExecuteResponse> {
@@ -79,14 +79,14 @@ impl Cw82Contract {
                 msg: msg.into()
             })?
         };
-        let binary_res = deps.querier.query(&QueryRequest::Wasm(wasm_query))?;
+        let binary_res = querier.query(&QueryRequest::Wasm(wasm_query))?;
         from_binary(&binary_res)
     }
 
 
     pub fn supports_interface(
-        &self,
-        deps: Deps,
+        &self,        
+        querier: &QuerierWrapper,
     ) -> StdResult<bool> {
 
         let key = cosmwasm_std::storage_keys::namespace_with_key(
@@ -99,7 +99,7 @@ impl Cw82Contract {
             key: key.into()
         };
 
-        let version : Option<String> = deps.querier.query(&QueryRequest::Wasm(raw_query))?;
+        let version : Option<String> = querier.query(&QueryRequest::Wasm(raw_query))?;
         Ok(version.is_some())
     }
 

--- a/packages/cw82/src/interface.rs
+++ b/packages/cw82/src/interface.rs
@@ -1,5 +1,5 @@
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::{CosmosMsg, Addr, StdResult, WasmMsg, to_binary, Binary, Deps, QueryRequest, WasmQuery, from_binary, Empty, QuerierWrapper};
+use cosmwasm_std::{CosmosMsg, Addr, StdResult, WasmMsg, to_binary, Binary, QueryRequest, WasmQuery, from_binary, Empty, QuerierWrapper};
 use cw1::CanExecuteResponse;
 use cw81::{ValidSignatureResponse, ValidSignaturesResponse};
 

--- a/packages/cw82/src/lib.rs
+++ b/packages/cw82/src/lib.rs
@@ -4,7 +4,7 @@ mod interface;
 pub use cw1::CanExecuteResponse;
 pub use cw2::ContractVersion;
 pub use cw81::{ValidSignatureResponse, ValidSignaturesResponse};
-pub use cw82_derive::{smart_account_query, basic_smart_account_query};
+pub use cw82_derive::smart_account_query;
 
 pub use msg::{Cw82QueryMsg, Cw82ExecuteMsg};
 pub use interface::{Cw82Contract, INTERFACE_NAME};

--- a/packages/cw82/src/msg.rs
+++ b/packages/cw82/src/msg.rs
@@ -1,18 +1,35 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{CosmosMsg, Binary, Empty};
-
-use cw1::{CanExecuteResponse, Cw1ExecuteMsg};
-use cw81::{ValidSignatureResponse, ValidSignaturesResponse};
-use cw82_derive::{smart_account_query};
+use cw1::{Cw1ExecuteMsg, CanExecuteResponse};
 
 use schemars::JsonSchema;
 use std::fmt;
 
-#[smart_account_query]
 #[cw_serde]
 #[derive(QueryResponses)]
 pub enum Cw82QueryMsg <T = Empty>
-where T: Clone + fmt::Debug + PartialEq + JsonSchema {}
+where T: Clone + fmt::Debug + PartialEq + JsonSchema {
+    #[returns(CanExecuteResponse)]
+    CanExecute { 
+        sender: String, 
+        msg: CosmosMsg<T> 
+    },
+
+    /// cw81
+    #[returns(cw81::ValidSignatureResponse)]
+    ValidSignature {
+        data: Binary,
+        signature: Binary,
+        payload: Option<Binary>
+    },
+
+    #[returns(::cw81::ValidSignaturesResponse)]
+    ValidSignatures {
+        data: Vec<Binary>,
+        signatures: Vec<Binary>,
+        payload: Option<Binary>
+    }
+}
 
 
 

--- a/packages/cw83/README.md
+++ b/packages/cw83/README.md
@@ -40,7 +40,7 @@ struct AccountInfoResponse<T = Empty> {
 
 ## Messages
 
-The only requred message variant for the execute endpoint is the following:
+The only required message variant for the execute endpoint is `CreateAccount``:
 
 ```rust
 enum ExecuteMsg {
@@ -64,16 +64,16 @@ allowing contracts to define payload needed for validation in the registry and a
 
 ## Usage
 
-A contract that wishes to follow the standard must add the variants described above to their query and execute messages. This package exposes a helper macro attribute `registy_query` that injects it automatically:
+A contract that wishes to follow the standard must add the variants described above to their query and execute messages. This package exposes a helper macro attribute `registry_query` that injects it automatically:
 
 ```Rust
-#[registy_query] // <- Must be before #[cw_serde]
+#[registry_query] // <- Must be before #[cw_serde]
 #[cw_serde]
 #[derive(QueryResponses)]
 enum QueryMsg {}
 ```
 
-The module where the message is defined must ether import `AccountQuery` from cw83 package or to define it manually. Here is an example of customising it from token bound account registry:
+Modules using the message must ether import `AccountQuery` from cw83 package or to define it manually. Here is an example of customising it from token bound account registry:
 
 ```Rust
 use cw83::AccountQuery as AccountQueryBase;
@@ -91,12 +91,14 @@ pub type AccountQuery = AccountQueryBase<TokenInfo>;
 Defining execute message can also happen through a helper
 
 ```Rust
-#[registy_execute]
+#[registry_execute]
 #[cw_serde]
 pub enum Cw83ExecuteMsg {}
 ```
+Note: `AccountQuery` must also be imported
 
-In similar manner `CreateAccountMsg` must also be imported. An example of customizing a message from the tba-registry:
+
+Same scenario must be repeated for `CreateAccountMsg`. An example of customizing a message from the tba-registry:
 
 ```rust
 use cw83::CreateAccountMsg as CreateAccountMsgBase

--- a/packages/cw83/derive/src/lib.rs
+++ b/packages/cw83/derive/src/lib.rs
@@ -46,7 +46,7 @@ fn merge_variants(metadata: TokenStream, left: TokenStream, right: TokenStream) 
 
 
 #[proc_macro_attribute]
-pub fn registy_query(metadata: TokenStream, input: TokenStream) -> TokenStream {
+pub fn registry_query(metadata: TokenStream, input: TokenStream) -> TokenStream {
     merge_variants(
         metadata,
         input,
@@ -62,7 +62,7 @@ pub fn registy_query(metadata: TokenStream, input: TokenStream) -> TokenStream {
 
 
  #[proc_macro_attribute]
-pub fn registy_execute(metadata: TokenStream, input: TokenStream) -> TokenStream {
+pub fn registry_execute(metadata: TokenStream, input: TokenStream) -> TokenStream {
     merge_variants(
         metadata,
         input,

--- a/packages/cw83/derive/src/lib.rs
+++ b/packages/cw83/derive/src/lib.rs
@@ -46,40 +46,6 @@ fn merge_variants(metadata: TokenStream, left: TokenStream, right: TokenStream) 
 
 
 #[proc_macro_attribute]
-pub fn smart_account_query(metadata: TokenStream, input: TokenStream) -> TokenStream {
-    merge_variants(
-        metadata,
-        input,
-        quote! {
-            enum Right {
-
-                /// cw1
-                #[returns(CanExecuteResponse)]
-                CanExecute { sender: String, msg: CosmosMsg<T> },
-
-
-                /// cw81
-                #[returns(ValidSignatureResponse)]
-                ValidSignature {
-                    data: Binary,
-                    signature: Binary,
-                    payload: Option<Binary>
-                },
-
-                #[returns(ValidSignaturesResponse)]
-                ValidSignatures {
-                    data: Vec<Binary>,
-                    signatures: Vec<Binary>,
-                    payload: Option<Binary>
-                }
-            }
-        }
-        .into(),
-    )
-}
-
-
-#[proc_macro_attribute]
 pub fn registy_query(metadata: TokenStream, input: TokenStream) -> TokenStream {
     merge_variants(
         metadata,

--- a/packages/cw83/src/lib.rs
+++ b/packages/cw83/src/lib.rs
@@ -1,6 +1,6 @@
 mod msg;
 mod registry;
 
-pub use cw83_derive::{registy_execute, registy_query};
+pub use cw83_derive::{registry_execute, registry_query};
 pub use registry::{Cw83RegistryBase, INTERFACE_NAME, CREATE_ACCOUNT_REPLY_ID};
 pub use msg::{Cw83ExecuteMsg, Cw83QueryMsg, CreateAccountMsg, AccountInfoResponse, AccountQuery};

--- a/packages/cw83/src/msg.rs
+++ b/packages/cw83/src/msg.rs
@@ -1,6 +1,5 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{Empty, Binary};
-use cw83_derive::{registy_query, registy_execute};
 
 
 #[cw_serde]
@@ -22,12 +21,15 @@ pub struct CreateAccountMsg<T = Binary> {
 }
 
 
-#[registy_query]
 #[cw_serde]
 #[derive(QueryResponses)]
-pub enum Cw83QueryMsg {}
+pub enum Cw83QueryMsg {
+    #[returns(AccountInfoResponse)]
+    AccountInfo(AccountQuery)
+}
 
 
-#[registy_execute]
 #[cw_serde]
-pub enum Cw83ExecuteMsg {}
+pub enum Cw83ExecuteMsg {
+    CreateAccount(CreateAccountMsg)
+}

--- a/packages/cw83/src/registry.rs
+++ b/packages/cw83/src/registry.rs
@@ -1,29 +1,11 @@
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::{CosmosMsg, Addr, StdResult, WasmMsg, Coin, Binary, SubMsg, ReplyOn, Deps, WasmQuery, QueryRequest};
+use cosmwasm_std::{CosmosMsg, Addr, StdResult, WasmMsg, Coin, Binary, SubMsg, ReplyOn, WasmQuery, QueryRequest, QuerierWrapper};
 
 
 pub const CREATE_ACCOUNT_REPLY_ID : u64 = 82;
 pub const INTERFACE_NAME: &str = "crates:cw83";
 
 
-/* trait Cw83Registry<T> {
-    fn addr(&self) -> Addr;
-    fn create_account_init_msg(
-        &self, 
-        code_id: u64, 
-        init_msg: Binary, 
-        funds: Vec<Coin>,
-        label: String
-    ) -> StdResult<CosmosMsg<T>>;
-    fn create_account_sub_msg(
-        &self,
-        code_id: u64, 
-        init_msg: Binary, 
-        funds: Vec<Coin>,
-        label: String
-    ) -> StdResult<SubMsg<T>>;
-}
- */
 
 #[cw_serde]
 pub struct Cw83RegistryBase (pub Addr);
@@ -77,7 +59,7 @@ impl Cw83RegistryBase {
     
     pub fn supports_interface(
         &self,
-        deps: Deps,
+        querier: &QuerierWrapper,
     ) -> StdResult<bool> {
 
         let key = cosmwasm_std::storage_keys::namespace_with_key(
@@ -90,7 +72,7 @@ impl Cw83RegistryBase {
             key: key.into()
         };
 
-        let version : Option<String> = deps.querier.query(&QueryRequest::Wasm(raw_query))?;
+        let version : Option<String> = querier.query(&QueryRequest::Wasm(raw_query))?;
         Ok(version.is_some())
     }
 


### PR DESCRIPTION
Remove a requirement to explicitly import argument and return value type when expanding `QueryMsg` and `ExecuteMsg` for cw81 and cw81

cw83 remains as is to allow for customisation with generics 